### PR TITLE
Improve Clojure execution and template

### DIFF
--- a/templates/template_clojure.md
+++ b/templates/template_clojure.md
@@ -2,7 +2,21 @@ You are a clojure programmer. Write a clojure program for the following problem:
 
 $$$PROBLEM$$$
 
-The clojure program must not use any file IO. It should also not have any user inputs.
-The clojure program should not use any imports unless absolutely necessary for the solution.
-The clojure program must not output any comment lines or debugging lines,
-it must just output a single value which is the solution of the problem.
+IMPORTANT REQUIREMENTS:
+- Your code will be executed with `clj -M -e "<your-code>"`, so write a simple inline script that prints the answer
+- DO NOT use `(ns ...)` namespace declarations
+- DO NOT use `-main` functions - write inline code instead
+- You may define helper functions with `defn`, but make sure to call them and print the result
+- DO NOT use any file I/O - if the problem includes data files, hardcode the data directly in your solution
+- Your code must print exactly one value: the numeric answer to the problem
+- Use `(println ...)` to output the final result
+- Wrap your code in a clojure code block using triple backticks
+
+EXAMPLE FORMAT:
+```clojure
+(println (reduce + (range 1 101)))
+```
+
+This would output `5050` for the sum of numbers 1-100.
+
+Now solve the problem above following these rules exactly.


### PR DESCRIPTION
Thanks for making this, its going to come in useful for my own personal LLM performance tracking for Clojure. I was just testing gpt-5-codex and was only marginally beating 4.1 scores but there seemed to be some common issues in the process so I made some small changes. You likely have your own mark set now but thought I'd raise a PR anyway in case anything in here was useful to you.

This turned my gpt-5 codex score from 14 to 26 although I do notice some are just straight up answered from training data, no full code supplied, just like `(println "anwser")` and thats the it, I may also try and fix this.

I also notice that maybe about 10 of the 1-100 problems have datasets that are not included in the question, codex burns a massive amount of tokens trying its best to replicate some of these in thinking tokens, gives up then just pulls something from training data. I might try and fix this as at the moment it makes me scared to run it on Anthropic for opus etc due to the cost.

- Fix execute.py to handle -main functions by auto-calling them if instruction ignored
- Fix execute.py to strip namespace declarations (incompatible with clj -e)
- Improve answer extraction from non-code responses (finds answers in markdown text)
- Enhance template_clojure.md with clearer requirements and examples
- Explicitly forbid namespace declarations and -main functions in template
- Add example showing expected code structure